### PR TITLE
Fix add_gene_ratio return

### DIFF
--- a/src/string_gsea/network.py
+++ b/src/string_gsea/network.py
@@ -12,7 +12,6 @@ def add_gene_ratio(df: pl.DataFrame) -> pl.DataFrame:
     return df.with_columns(
         (pl.col("genesMapped") / pl.col("genesInSet")).alias("geneRatio")
     )
-    return df
 
 
 def separate_pivot_longer(df: pl.DataFrame) -> pl.DataFrame:


### PR DESCRIPTION
## Summary
- remove unreachable return in `add_gene_ratio`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'string_gsea')*

------
https://chatgpt.com/codex/tasks/task_e_684c0b402cb08320b3b72ce8658f5e92